### PR TITLE
manifest: Allow installation on tablets via Google Play.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,10 @@
             android:name="android.hardware.sensor.gyroscope"
             android:required="true"/>
 
+    <uses-feature
+            android:name="android.hardware.telephony"
+            android:required="false"/>
+
     <application
             android:allowBackup="true"
             android:fullBackupContent="@xml/backup_descriptor"


### PR DESCRIPTION
Add uses-feature android.hardware.telephony required=false.
Totally untested.

See: https://stackoverflow.com/questions/42631701/my-android-application-not-compatible-with-tablet